### PR TITLE
[debian] wait for property service by socket

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/debian/urfkill.upstart.in
+++ b/debian/urfkill.upstart.in
@@ -12,12 +12,26 @@ stop on stopping dbus
 respawn
 
 script
-    # If this is a touch device we wait for Android property system to be up.
-    # Also, we have made sure in the system image that if urfkill.hybris.wlan
-    # exists, it has been set before wifi.interface (this last one exists for
-    # all devices, so we should eventually get out of the loop).
+    # If this is a touch device, we have to wait until Android property system
+    # is up AND the properties are loaded.
+
+    # If using getprop alone, it can fallback to /system/build.prop, thus not
+    # ensuring the property is up. Some device (e.g. krillin) uses property
+    # service to control wifi, thus this is required.
+
+    # In the other hand, properties can be loaded after the socket appears (at
+    # least in Halium 7.1). If not waiting for that, we might miss the urfkill.
+    # hybris.wlan property. We have made sure in the system image that if
+    # urfkill.hybris.wlan exists, it has been set before wifi.interface (this
+    # last one exists for all devices, so we should eventually get out of the
+    # loop).
+
     if [ -f /usr/bin/getprop ]
     then
+        # Wait for the property system to be up.
+        while [ ! -e /dev/socket/property_service ]; do sleep 0.1; done
+
+        # Wait for properties to be loaded.
         while [ -z "$(getprop wifi.interface)" ]; do sleep 0.2; done
     fi
 


### PR DESCRIPTION
If using getprop alone, it can fallback to /system/build.prop, thus not
ensuring the property is up. Some device (e.g. krillin) uses property
service to control wifi, thus this is required.

This stems from my ueventd-as-a-udevtrigger effort which prevents
double-coldbooting and fixes FP2's camera on Halium 7.1 port. However,
this means the start of udev doesn't guarantee the start of Android
container anymore. Thus, a better check is required.

This PR comes with Jenkinsfile update.

Related PR: https://github.com/ubports/lxc-android-config/pull/26